### PR TITLE
feat: add public key to limits endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/pokt-foundation/portal-api-go v0.1.4
+	github.com/pokt-foundation/portal-api-go v0.1.5
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/portal-api-go v0.1.4 h1:EV4aA7+gBSAAdq6uPMjmPmS7SuPMKvSV5BOT91/+1RE=
-github.com/pokt-foundation/portal-api-go v0.1.4/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
+github.com/pokt-foundation/portal-api-go v0.1.5 h1:yZl21eLmtzersO33SGslLR1oGT+yJ/ELgJwYLo68Z9k=
+github.com/pokt-foundation/portal-api-go v0.1.5/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/router/router.go
+++ b/router/router.go
@@ -124,6 +124,7 @@ func (rt *Router) GetApplicationsLimits(w http.ResponseWriter, r *http.Request) 
 	for _, app := range apps {
 		appsLimits = append(appsLimits, repository.AppLimits{
 			AppID:      app.ID,
+			PublicKey:  app.FreeTierApplicationAccount.PublicKey,
 			DailyLimit: app.Limits.DailyLimit,
 		})
 	}


### PR DESCRIPTION
Adds public key to apps limit endpoint to be able to query it in the relay meter.