### PR TITLE
chore: set plan type to empty in update app

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -196,6 +196,7 @@ func (c *Cache) UpdateApplication(app *repository.Application) {
 			PlanType:   newPlan.PlanType,
 			DailyLimit: newPlan.DailyLimit,
 		}
+		app.PayPlanType = "" // set to empty to avoid two sources of truth
 	}
 
 	c.applicationsMux.Lock()


### PR DESCRIPTION
Set payPlanType to empty in updateApplication, to avoid having two fields with the same data