### PR TITLE
Pascal/add redirects

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -461,12 +461,12 @@ func (c *Cache) AddRedirect(redirect *repository.Redirect) {
 	c.blockchainsMux.Lock()
 	defer c.blockchainsMux.Unlock()
 
-	blockchain := c.blockchainsMap[redirect.BlockchainID]
+	if blockchain, exists := c.blockchainsMap[redirect.BlockchainID]; exists {
+		blockchain.Redirects = append(blockchain.Redirects, *redirect)
 
-	blockchain.Redirects = append(blockchain.Redirects, *redirect)
-
-	c.blockchains = updateBlockchainFromSlice(blockchain, c.blockchains)
-	c.blockchainsMap[blockchain.ID] = blockchain
+		c.blockchains = updateBlockchainFromSlice(blockchain, c.blockchains)
+		c.blockchainsMap[redirect.BlockchainID] = blockchain
+	}
 }
 
 func (c *Cache) setUsers() error {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -63,6 +63,21 @@ func TestCache_SetCache(t *testing.T) {
 		},
 	}, nil)
 
+	readerMock.On("ReadRedirects").Return([]*repository.Redirect{
+		{
+			BlockchainID:   "0021",
+			Alias:          "pokt-mainnet",
+			Domain:         "pokt-mainnet.gateway.network",
+			LoadBalancerID: "12345",
+		},
+		{
+			BlockchainID:   "0022",
+			Alias:          "eth-mainnet",
+			Domain:         "eth-mainnet.gateway.network",
+			LoadBalancerID: "45678",
+		},
+	}, nil)
+
 	cache := NewCache(readerMock)
 
 	err := cache.SetCache()
@@ -84,6 +99,9 @@ func TestCache_SetCache(t *testing.T) {
 
 	c.NotEmpty(cache.GetPayPlan(repository.FreetierV0))
 	c.Len(cache.GetPayPlans(), 2)
+
+	c.NotEmpty(cache.GetRedirects("0021"))
+	c.Len(cache.GetRedirects("0021"), 1)
 }
 
 func TestCache_SetCacheFailure(t *testing.T) {
@@ -105,6 +123,26 @@ func TestCache_SetCacheFailure(t *testing.T) {
 		{
 			PlanType:   repository.PayAsYouGoV0,
 			DailyLimit: 0,
+		},
+	}, nil)
+
+	readerMock.On("ReadRedirects").Return([]*repository.Redirect{}, errors.New("error on redirects")).Once()
+
+	err = cache.SetCache()
+	c.EqualError(err, "error on redirects")
+
+	readerMock.On("ReadRedirects").Return([]*repository.Redirect{
+		{
+			BlockchainID:   "0021",
+			Alias:          "pokt-mainnet",
+			Domain:         "pokt-mainnet.gateway.network",
+			LoadBalancerID: "12345",
+		},
+		{
+			BlockchainID:   "0022",
+			Alias:          "eth-mainnet",
+			Domain:         "eth-mainnet.gateway.network",
+			LoadBalancerID: "45678",
 		},
 	}, nil)
 

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -39,3 +39,9 @@ func (r *ReaderMock) ReadPayPlans() ([]*repository.PayPlan, error) {
 
 	return args.Get(0).([]*repository.PayPlan), args.Error(1)
 }
+
+func (r *ReaderMock) ReadRedirects() ([]*repository.Redirect, error) {
+	args := r.Called()
+
+	return args.Get(0).([]*repository.Redirect), args.Error(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/pokt-foundation/portal-api-go v0.3.0
+	github.com/pokt-foundation/portal-api-go v0.3.1
 	github.com/pokt-foundation/utils-go v0.2.3
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/pokt-foundation/portal-api-go v0.3.1
-	github.com/pokt-foundation/utils-go v0.2.3
+	github.com/pokt-foundation/utils-go v0.2.4
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/pokt-foundation/portal-api-go v0.2.7
+	github.com/pokt-foundation/portal-api-go v0.2.9
 	github.com/pokt-foundation/utils-go v0.2.2
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/pokt-foundation/portal-api-go v0.2.9
+	github.com/pokt-foundation/portal-api-go v0.3.0
 	github.com/pokt-foundation/utils-go v0.2.2
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/portal-api-go v0.3.0 h1:vATfQwTGG03wEZOq5s7kRY0jsuMRr3kKoQdLzg2xirI=
-github.com/pokt-foundation/portal-api-go v0.3.0/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
+github.com/pokt-foundation/portal-api-go v0.3.1 h1:+nqBU3W45ZyEFjXyUVGLnfqCakRQTdWu7DvjKk8Gx2Q=
+github.com/pokt-foundation/portal-api-go v0.3.1/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
 github.com/pokt-foundation/utils-go v0.2.3 h1:ZrHHl/HlsCPP76lBtFQqli3e7KSgsVs6tLM7i8KfJ2s=
 github.com/pokt-foundation/utils-go v0.2.3/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/portal-api-go v0.2.7 h1:O2ED0ZRKVl8aGUCKRdUk6ueevnItt0JGVRMxc+7cpms=
-github.com/pokt-foundation/portal-api-go v0.2.7/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
+github.com/pokt-foundation/portal-api-go v0.2.9 h1:UGbkiN++YjMHyXiGXhz6Ibc68MB0CjVPTKXhAU/x6DY=
+github.com/pokt-foundation/portal-api-go v0.2.9/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
 github.com/pokt-foundation/utils-go v0.2.2 h1:5qQvmhqEgkrf7GMXlvLJrMrA6jkbr88OU7qKyxb9n+0=
 github.com/pokt-foundation/utils-go v0.2.2/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/portal-api-go v0.2.9 h1:UGbkiN++YjMHyXiGXhz6Ibc68MB0CjVPTKXhAU/x6DY=
-github.com/pokt-foundation/portal-api-go v0.2.9/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
+github.com/pokt-foundation/portal-api-go v0.3.0 h1:vATfQwTGG03wEZOq5s7kRY0jsuMRr3kKoQdLzg2xirI=
+github.com/pokt-foundation/portal-api-go v0.3.0/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
 github.com/pokt-foundation/utils-go v0.2.2 h1:5qQvmhqEgkrf7GMXlvLJrMrA6jkbr88OU7qKyxb9n+0=
 github.com/pokt-foundation/utils-go v0.2.2/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pokt-foundation/portal-api-go v0.3.1 h1:+nqBU3W45ZyEFjXyUVGLnfqCakRQTdWu7DvjKk8Gx2Q=
 github.com/pokt-foundation/portal-api-go v0.3.1/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
-github.com/pokt-foundation/utils-go v0.2.3 h1:ZrHHl/HlsCPP76lBtFQqli3e7KSgsVs6tLM7i8KfJ2s=
-github.com/pokt-foundation/utils-go v0.2.3/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
+github.com/pokt-foundation/utils-go v0.2.4 h1:1OntN55cxnbvpRjI7g5ndk9duZ9B7SPwe0EJsHKXZ7g=
+github.com/pokt-foundation/utils-go v0.2.4/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	connectionString = environment.MustGetString("CONNECTION_STRING")
+	apiKeys          = environment.MustGetStringMap("API_KEYS", ",")
 
 	cacheRefresh = environment.GetInt64("CACHE_REFRESH", 10)
 	port         = environment.GetString("PORT", "8080")
@@ -43,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	router, err := router.NewRouter(driver, driver)
+	router, err := router.NewRouter(driver, driver, apiKeys)
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	port             = environment.GetString("PORT", "8080")
-	cacheRefresh     = environment.GetInt64("CACHE_REFRESH", 10)
-	connectionString = environment.GetString("CONNECTION_STRING", "")
+	connectionString = environment.MustGetString("CONNECTION_STRING")
+
+	cacheRefresh = environment.GetInt64("CACHE_REFRESH", 10)
+	port         = environment.GetString("PORT", "8080")
 )
 
 func cacheHandler(router *router.Router) {

--- a/router/router.go
+++ b/router/router.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	apiKeys = environment.GetStringMap("API_KEYS", "", ",")
+	apiKeys = environment.MustGetStringMap("API_KEYS", ",")
 )
 
 // Writer represents the implementation of writer interface

--- a/router/router.go
+++ b/router/router.go
@@ -24,6 +24,9 @@ type Writer interface {
 	WriteApplication(app *repository.Application) (*repository.Application, error)
 	UpdateApplication(id string, options *repository.UpdateApplication) error
 	RemoveApplication(id string) error
+	WriteBlockchain(blockchain *repository.Blockchain) (*repository.Blockchain, error)
+	WriteRedirect(redirect *repository.Redirect) (*repository.Redirect, error)
+	ActivateBlockchain(id string, active bool) error
 }
 
 // Router struct handler for router requests
@@ -50,7 +53,9 @@ func NewRouter(reader cache.Reader, writer Writer) (*Router, error) {
 
 	rt.Router.HandleFunc("/", rt.HealthCheck).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/blockchain", rt.GetBlockchains).Methods(http.MethodGet)
+	rt.Router.HandleFunc("/blockchain", rt.CreateBlockchain).Methods(http.MethodPost)
 	rt.Router.HandleFunc("/blockchain/{id}", rt.GetBlockchain).Methods(http.MethodGet)
+	rt.Router.HandleFunc("/blockchain/{id}/activate", rt.ActivateBlockchain).Methods(http.MethodPost)
 	rt.Router.HandleFunc("/application", rt.GetApplications).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/application", rt.CreateApplication).Methods(http.MethodPost)
 	rt.Router.HandleFunc("/application/limits", rt.GetApplicationsLimits).Methods(http.MethodGet)
@@ -66,6 +71,7 @@ func NewRouter(reader cache.Reader, writer Writer) (*Router, error) {
 	rt.Router.HandleFunc("/user/{id}/load_balancer", rt.GetLoadBalancerByUserID).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/pay_plan", rt.GetPayPlans).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/pay_plan/{type}", rt.GetPayPlan).Methods(http.MethodGet)
+	rt.Router.HandleFunc("/redirect", rt.CreateRedirects).Methods(http.MethodPost)
 
 	rt.Router.Use(rt.AuthorizationHandler)
 
@@ -261,6 +267,57 @@ func (rt *Router) GetBlockchain(w http.ResponseWriter, r *http.Request) {
 	jsonresponse.RespondWithJSON(w, http.StatusOK, blockchain)
 }
 
+func (rt *Router) ActivateBlockchain(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	blockchainID := vars["id"]
+
+	var active bool
+
+	decoder := json.NewDecoder(r.Body)
+
+	err := decoder.Decode(&active)
+	if err != nil {
+		jsonresponse.RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	defer r.Body.Close()
+
+	err = rt.Writer.ActivateBlockchain(blockchainID, active)
+	if err != nil {
+		jsonresponse.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	rt.Cache.ActivateBlockchain(blockchainID, active)
+
+	jsonresponse.RespondWithJSON(w, http.StatusOK, active)
+}
+
+func (rt *Router) CreateBlockchain(w http.ResponseWriter, r *http.Request) {
+	var blockchain repository.Blockchain
+
+	decoder := json.NewDecoder(r.Body)
+
+	err := decoder.Decode(&blockchain)
+	if err != nil {
+		jsonresponse.RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	defer r.Body.Close()
+
+	fullBlockchain, err := rt.Writer.WriteBlockchain(&blockchain)
+	if err != nil {
+		jsonresponse.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	rt.Cache.AddBlockchain(fullBlockchain)
+
+	jsonresponse.RespondWithJSON(w, http.StatusOK, fullBlockchain)
+}
+
 func (rt *Router) GetBlockchains(w http.ResponseWriter, r *http.Request) {
 	jsonresponse.RespondWithJSON(w, http.StatusOK, rt.Cache.GetBlockchains())
 }
@@ -387,4 +444,34 @@ func (rt *Router) GetPayPlan(w http.ResponseWriter, r *http.Request) {
 
 func (rt *Router) GetPayPlans(w http.ResponseWriter, r *http.Request) {
 	jsonresponse.RespondWithJSON(w, http.StatusOK, rt.Cache.GetPayPlans())
+}
+
+func (rt *Router) CreateRedirects(w http.ResponseWriter, r *http.Request) {
+	var redirect []repository.Redirect
+
+	decoder := json.NewDecoder(r.Body)
+
+	err := decoder.Decode(&redirect)
+	if err != nil {
+		jsonresponse.RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	defer r.Body.Close()
+
+	fullRedirects := []*repository.Redirect{}
+
+	for _, redirect := range redirect {
+		fullRedirect, err := rt.Writer.WriteRedirect(&redirect)
+		if err != nil {
+			jsonresponse.RespondWithError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rt.Cache.AddRedirect(fullRedirect)
+
+		fullRedirects = append(fullRedirects, fullRedirect)
+	}
+
+	jsonresponse.RespondWithJSON(w, http.StatusOK, fullRedirects)
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -57,6 +57,32 @@ func (w *writerMock) RemoveApplication(id string) error {
 func newTestRouter() (*Router, error) {
 	readerMock := &cache.ReaderMock{}
 
+	readerMock.On("ReadPayPlans").Return([]*repository.PayPlan{
+		{
+			PlanType:   repository.FreetierV0,
+			DailyLimit: 250000,
+		},
+		{
+			PlanType:   repository.PayAsYouGoV0,
+			DailyLimit: 0,
+		},
+	}, nil)
+
+	readerMock.On("ReadRedirects").Return([]*repository.Redirect{
+		{
+			BlockchainID:   "0021",
+			Alias:          "pokt-mainnet",
+			Domain:         "pokt-mainnet.gateway.network",
+			LoadBalancerID: "12345",
+		},
+		{
+			BlockchainID:   "0022",
+			Alias:          "eth-mainnet",
+			Domain:         "eth-mainnet.gateway.network",
+			LoadBalancerID: "45678",
+		},
+	}, nil)
+
 	readerMock.On("ReadApplications").Return([]*repository.Application{
 		{
 			ID:          "5f62b7d8be3591c4dea8566d",
@@ -106,17 +132,6 @@ func newTestRouter() (*Router, error) {
 		},
 		{
 			ID: "60ecb2bf67774900350d9c44",
-		},
-	}, nil)
-
-	readerMock.On("ReadPayPlans").Return([]*repository.PayPlan{
-		{
-			PlanType:   repository.FreetierV0,
-			DailyLimit: 250000,
-		},
-		{
-			PlanType:   repository.PayAsYouGoV0,
-			DailyLimit: 0,
 		},
 	}, nil)
 
@@ -539,9 +554,25 @@ func TestRouter_GetBlockchains(t *testing.T) {
 	expectedBody, err := json.Marshal([]*repository.Blockchain{
 		{
 			ID: "0021",
+			Redirects: []repository.Redirect{
+				{
+					BlockchainID:   "0021",
+					Alias:          "pokt-mainnet",
+					Domain:         "pokt-mainnet.gateway.network",
+					LoadBalancerID: "12345",
+				},
+			},
 		},
 		{
 			ID: "0022",
+			Redirects: []repository.Redirect{
+				{
+					BlockchainID:   "0022",
+					Alias:          "eth-mainnet",
+					Domain:         "eth-mainnet.gateway.network",
+					LoadBalancerID: "45678",
+				},
+			},
 		},
 	})
 	c.NoError(err)
@@ -566,6 +597,14 @@ func TestRouter_GetBlockchain(t *testing.T) {
 
 	expectedBody, err := json.Marshal(&repository.Blockchain{
 		ID: "0021",
+		Redirects: []repository.Redirect{
+			{
+				BlockchainID:   "0021",
+				Alias:          "pokt-mainnet",
+				Domain:         "pokt-mainnet.gateway.network",
+				LoadBalancerID: "12345",
+			},
+		},
 	})
 	c.NoError(err)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -153,7 +153,7 @@ func newTestRouter() (*Router, error) {
 		},
 	}, nil)
 
-	return NewRouter(readerMock, nil)
+	return NewRouter(readerMock, nil, map[string]bool{"": true})
 }
 
 func TestRouter_HealthCheck(t *testing.T) {


### PR DESCRIPTION
Adds caching of Redirects and attaching them to the Blockchains when setting the cache.

Tested locally with Portal API Go changes via Postman to ensure Redirects and sync check options are added to the Blockchains correctly.