### PR TITLE
feat: delete get users and user endpoints

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -46,12 +46,6 @@ func TestCache_SetCache(t *testing.T) {
 		},
 	}, nil)
 
-	readerMock.On("ReadUsers").Return([]*repository.User{
-		{
-			ID: "60ecb2bf67774900350d9c43",
-		},
-	}, nil)
-
 	readerMock.On("ReadPayPlans").Return([]*repository.PayPlan{
 		{
 			PlanType:   repository.FreetierV0,
@@ -93,9 +87,6 @@ func TestCache_SetCache(t *testing.T) {
 	c.NotEmpty(cache.GetLoadBalancer("60ecb2bf67774900350d9c42"))
 	c.Len(cache.GetLoadBalancers(), 1)
 	c.Len(cache.GetLoadBalancersByUserID("60ecb35fts687463gh2h72gs"), 1)
-
-	c.NotEmpty(cache.GetUser("60ecb2bf67774900350d9c43"))
-	c.Len(cache.GetUsers(), 1)
 
 	c.NotEmpty(cache.GetPayPlan(repository.FreetierV0))
 	c.Len(cache.GetPayPlans(), 2)
@@ -179,11 +170,6 @@ func TestCache_SetCacheFailure(t *testing.T) {
 			ID: "60ecb2bf67774900350d9c42",
 		},
 	}, nil)
-
-	readerMock.On("ReadUsers").Return([]*repository.User{}, errors.New("error on users")).Once()
-
-	err = cache.SetCache()
-	c.EqualError(err, "error on users")
 }
 
 func TestCache_AddApplication(t *testing.T) {

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -28,12 +28,6 @@ func (r *ReaderMock) ReadLoadBalancers() ([]*repository.LoadBalancer, error) {
 	return args.Get(0).([]*repository.LoadBalancer), args.Error(1)
 }
 
-func (r *ReaderMock) ReadUsers() ([]*repository.User, error) {
-	args := r.Called()
-
-	return args.Get(0).([]*repository.User), args.Error(1)
-}
-
 func (r *ReaderMock) ReadPayPlans() ([]*repository.PayPlan, error) {
 	args := r.Called()
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
-	github.com/pokt-foundation/portal-api-go v0.3.7
+	github.com/pokt-foundation/portal-api-go v0.4.0
 	github.com/pokt-foundation/utils-go v0.2.4
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-foundation/portal-api-go v0.3.7 h1:oXObwF6tsmC0wpSmrbAr16sAsCIUXBe0zGP++ksHyXU=
-github.com/pokt-foundation/portal-api-go v0.3.7/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
+github.com/pokt-foundation/portal-api-go v0.4.0 h1:gJBM3Ssp8yxNB4JDq5ZSNQo99ihaycl51WNAhVjyMws=
+github.com/pokt-foundation/portal-api-go v0.4.0/go.mod h1:7T8GJ+dpbo39i+3nuNhByJLD3LfvgwCdzZjseKBeH/g=
 github.com/pokt-foundation/utils-go v0.2.4 h1:1OntN55cxnbvpRjI7g5ndk9duZ9B7SPwe0EJsHKXZ7g=
 github.com/pokt-foundation/utils-go v0.2.4/go.mod h1:c92FV9S9qY4PEyeOv4fGkI9FTZSv8oh1MiARGC+BC2E=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/router/router.go
+++ b/router/router.go
@@ -65,8 +65,6 @@ func NewRouter(reader cache.Reader, writer Writer, apiKeys map[string]bool) (*Ro
 	rt.Router.HandleFunc("/load_balancer", rt.CreateLoadBalancer).Methods(http.MethodPost)
 	rt.Router.HandleFunc("/load_balancer/{id}", rt.GetLoadBalancer).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/load_balancer/{id}", rt.UpdateLoadBalancer).Methods(http.MethodPut)
-	rt.Router.HandleFunc("/user", rt.GetUsers).Methods(http.MethodGet)
-	rt.Router.HandleFunc("/user/{id}", rt.GetUser).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/user/{id}/application", rt.GetApplicationByUserID).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/user/{id}/load_balancer", rt.GetLoadBalancerByUserID).Methods(http.MethodGet)
 	rt.Router.HandleFunc("/pay_plan", rt.GetPayPlans).Methods(http.MethodGet)
@@ -458,23 +456,6 @@ func (rt *Router) UpdateLoadBalancer(w http.ResponseWriter, r *http.Request) {
 
 func (rt *Router) GetLoadBalancers(w http.ResponseWriter, r *http.Request) {
 	jsonresponse.RespondWithJSON(w, http.StatusOK, rt.Cache.GetLoadBalancers())
-}
-
-func (rt *Router) GetUser(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-
-	user := rt.Cache.GetUser(vars["id"])
-
-	if user == nil {
-		jsonresponse.RespondWithError(w, http.StatusNotFound, "user not found")
-		return
-	}
-
-	jsonresponse.RespondWithJSON(w, http.StatusOK, user)
-}
-
-func (rt *Router) GetUsers(w http.ResponseWriter, r *http.Request) {
-	jsonresponse.RespondWithJSON(w, http.StatusOK, rt.Cache.GetUsers())
 }
 
 func (rt *Router) GetPayPlan(w http.ResponseWriter, r *http.Request) {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -154,15 +154,6 @@ func newTestRouter() (*Router, error) {
 		},
 	}, nil)
 
-	readerMock.On("ReadUsers").Return([]*repository.User{
-		{
-			ID: "60ecb2bf67774900350d9c43",
-		},
-		{
-			ID: "60ecb2bf67774900350d9c44",
-		},
-	}, nil)
-
 	return NewRouter(readerMock, nil, map[string]bool{"": true})
 }
 
@@ -953,66 +944,6 @@ func TestRouter_RemoveLoadBalancer(t *testing.T) {
 	c.Equal(http.StatusOK, rr.Code)
 
 	req, err = http.NewRequest(http.MethodPut, "/load_balancer/5f62b7d8be3591c4dea85664", bytes.NewBuffer(updateInputToSend))
-	c.NoError(err)
-
-	rr = httptest.NewRecorder()
-
-	router.Router.ServeHTTP(rr, req)
-
-	c.Equal(http.StatusNotFound, rr.Code)
-}
-
-func TestRouter_GetUsers(t *testing.T) {
-	c := require.New(t)
-
-	req, err := http.NewRequest(http.MethodGet, "/user", nil)
-	c.NoError(err)
-
-	rr := httptest.NewRecorder()
-
-	router, err := newTestRouter()
-	c.NoError(err)
-
-	router.Router.ServeHTTP(rr, req)
-
-	c.Equal(http.StatusOK, rr.Code)
-
-	expectedBody, err := json.Marshal([]*repository.User{
-		{
-			ID: "60ecb2bf67774900350d9c43",
-		},
-		{
-			ID: "60ecb2bf67774900350d9c44",
-		},
-	})
-	c.NoError(err)
-
-	c.Equal(expectedBody, rr.Body.Bytes())
-}
-
-func TestRouter_GetUser(t *testing.T) {
-	c := require.New(t)
-
-	req, err := http.NewRequest(http.MethodGet, "/user/60ecb2bf67774900350d9c43", nil)
-	c.NoError(err)
-
-	rr := httptest.NewRecorder()
-
-	router, err := newTestRouter()
-	c.NoError(err)
-
-	router.Router.ServeHTTP(rr, req)
-
-	c.Equal(http.StatusOK, rr.Code)
-
-	expectedBody, err := json.Marshal(&repository.User{
-		ID: "60ecb2bf67774900350d9c43",
-	})
-	c.NoError(err)
-
-	c.Equal(expectedBody, rr.Body.Bytes())
-
-	req, err = http.NewRequest(http.MethodGet, "/user/61ecb2bf67774900350d9c43", nil)
 	c.NoError(err)
 
 	rr = httptest.NewRecorder()


### PR DESCRIPTION
Delete `GetUsers` and `GetUser` endpoints as they will no longer de supported from Portal API Go