### PR TITLE
T-14568 fix: update application and lb

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -192,10 +192,16 @@ func (c *Cache) UpdateApplication(app *repository.Application) {
 
 	c.applications = updateApplicationFromSlice(app, c.applications)
 	c.applicationsMap[app.ID] = app
-	c.applicationsMapByUserID[app.UserID] = append(c.applicationsMapByUserID[app.UserID], app)
+	c.applicationsMapByUserID[app.UserID] = updateApplicationFromSlice(app, c.applicationsMapByUserID[app.UserID])
 
-	for i := 0; i < len(c.loadBalancers); i++ {
-		updateApplicationFromSlice(app, c.loadBalancers[i].Applications)
+	for _, lb := range c.loadBalancers {
+		lb.Applications = updateApplicationFromSlice(app, lb.Applications)
+
+		c.loadBalancers = updateLoadBalancerFromSlice(lb, c.loadBalancers)
+
+		c.loadBalancersMap[lb.ID] = lb
+
+		c.loadBalancersMapByUserID[lb.UserID] = updateLoadBalancerFromSlice(lb, c.loadBalancersMapByUserID[lb.UserID])
 	}
 }
 
@@ -326,7 +332,7 @@ func (c *Cache) UpdateLoadBalancer(lb *repository.LoadBalancer) {
 
 	c.loadBalancersMap[lb.ID] = lb
 
-	c.loadBalancersMapByUserID[lb.UserID] = append(c.loadBalancersMapByUserID[lb.UserID], lb)
+	c.loadBalancersMapByUserID[lb.UserID] = updateLoadBalancerFromSlice(lb, c.loadBalancersMapByUserID[lb.UserID])
 }
 
 // DeleteLoadBalancer removes the load balancer from the cache

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -277,6 +277,7 @@ func TestCache_UpdateApplication(t *testing.T) {
 
 	cache.UpdateApplication(&repository.Application{
 		ID:          "5f62b7d8be3591c4dea8566a",
+		UserID:      "60ecb2bf67774900350d9c43",
 		Name:        "papolo",
 		PayPlanType: repository.FreetierV0,
 	})
@@ -287,6 +288,9 @@ func TestCache_UpdateApplication(t *testing.T) {
 	c.Equal("papolo", cache.GetApplication("5f62b7d8be3591c4dea8566a").Name)
 	c.Equal(250000, cache.GetApplication("5f62b7d8be3591c4dea8566a").Limits.DailyLimit)
 	c.Equal("papolo", cache.GetLoadBalancer("60ecb2bf67774900350d9c42").Applications[1].Name)
+	c.Equal("papolo", cache.GetApplicationsByUserID("60ecb2bf67774900350d9c43")[1].Name)
+	c.Equal("papolo", cache.GetLoadBalancer("60ecb2bf67774900350d9c42").Applications[1].Name)
+	c.Equal("papolo", cache.GetLoadBalancersByUserID("60ecb35fts687463gh2h72gs")[0].Applications[1].Name)
 }
 
 func TestCache_AddLoadBalancer(t *testing.T) {
@@ -361,13 +365,15 @@ func TestCache_UpdateLoadBalancer(t *testing.T) {
 	c.NoError(err)
 
 	cache.UpdateLoadBalancer(&repository.LoadBalancer{
-		ID:   "5f62b7d8be3591c4dea8566a",
-		Name: "papolo",
+		ID:     "5f62b7d8be3591c4dea8566a",
+		UserID: "60ecb2bf67774900350d9c43",
+		Name:   "papolo",
 	})
 
 	c.Len(cache.GetLoadBalancers(), 3)
 	c.Len(cache.GetLoadBalancersByUserID("60ecb2bf67774900350d9c43"), 2)
 	c.Len(cache.GetLoadBalancersByUserID("60ecb2bf67774900350d9c44"), 1)
+	c.Equal("papolo", cache.GetLoadBalancersByUserID("60ecb2bf67774900350d9c43")[1].Name)
 	c.Equal("papolo", cache.GetLoadBalancer("5f62b7d8be3591c4dea8566a").Name)
 }
 


### PR DESCRIPTION
- Fix updates of maps that return arrays (they were not actually being updated just appending a new record)
- Fix application update to also update records in all load balancer maps