### PR TITLE
chore: removed the need to store the pre-commit .pyz file in the repo itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ test_verbose:
 	go test ./... -v
 
 init-pre-commit:
+	curl https://github.com/pre-commit/pre-commit/releases/download/v2.20.0/pre-commit-2.20.0.pyz > pre-commit-2.20.0.pyz;
 	python3 pre-commit-2.20.0.pyz install;
 	python3 pre-commit-2.20.0.pyz autoupdate;
 	go install golang.org/x/tools/cmd/goimports@latest;
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;
 	go install -v github.com/go-critic/go-critic/cmd/gocritic@latest;
-	python3 pre-commit-2.20.0.pyz run --all-files;
+	python3 pre-commit-2.20.0.pyz run --all-files
+	rm pre-commit-2.20.0.pyz;


### PR DESCRIPTION
The .pyz file was not actually needed in the repo. Prefer simply downloading the .pyz file with cURL as part of the make init-pre-commit script and then removing the file after completion.