### PR TITLE
fix: updated main.go to use gatherOptions func for env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	CONNECTION_STRING = "CONNECTION_STRING"
-	API_KEYS          = "API_KEYS"
-	CACHE_REFRESH     = "CACHE_REFRESH"
-	PORT              = "PORT"
+	connectionString = "CONNECTION_STRING"
+	apiKeys          = "API_KEYS"
+	cacheRefresh     = "CACHE_REFRESH"
+	port             = "PORT"
 
-	CACHE_REFRESH_DEFAULT_MINUTES = 10
-	DEFAULT_PORT                  = "8080"
+	defaultCacheRefreshMinutes = 10
+	defaultPort                = "8080"
 )
 
 type options struct {
@@ -32,10 +32,10 @@ type options struct {
 
 func gatherOptions() options {
 	return options{
-		connectionString: environment.MustGetString(CONNECTION_STRING),
-		apiKeys:          environment.MustGetStringMap(API_KEYS, ","),
-		cacheRefresh:     environment.GetInt64(CACHE_REFRESH, CACHE_REFRESH_DEFAULT_MINUTES),
-		port:             environment.GetString(PORT, DEFAULT_PORT),
+		connectionString: environment.MustGetString(connectionString),
+		apiKeys:          environment.MustGetStringMap(apiKeys, ","),
+		cacheRefresh:     environment.GetInt64(cacheRefresh, defaultCacheRefreshMinutes),
+		port:             environment.GetString(port, defaultPort),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -13,41 +13,44 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	connectionString = environment.MustGetString("CONNECTION_STRING")
-	apiKeys          = environment.MustGetStringMap("API_KEYS", ",")
+const (
+	CONNECTION_STRING = "CONNECTION_STRING"
+	API_KEYS          = "API_KEYS"
+	CACHE_REFRESH     = "CACHE_REFRESH"
+	PORT              = "PORT"
 
-	cacheRefresh = environment.GetInt64("CACHE_REFRESH", 10)
-	port         = environment.GetString("PORT", "8080")
-
-	log = logrus.New()
+	CACHE_REFRESH_DEFAULT_MINUTES = 10
+	DEFAULT_PORT                  = "8080"
 )
 
-func init() {
-	// log as JSON instead of the default ASCII formatter.
-	log.SetFormatter(&logrus.JSONFormatter{})
+type options struct {
+	connectionString string
+	apiKeys          map[string]bool
+	cacheRefresh     int64
+	port             string
 }
 
-func logError(msg string, err error) {
-	fields := logrus.Fields{
-		"err": err.Error(),
+func gatherOptions() options {
+	return options{
+		connectionString: environment.MustGetString(CONNECTION_STRING),
+		apiKeys:          environment.MustGetStringMap(API_KEYS, ","),
+		cacheRefresh:     environment.GetInt64(CACHE_REFRESH, CACHE_REFRESH_DEFAULT_MINUTES),
+		port:             environment.GetString(PORT, DEFAULT_PORT),
 	}
-
-	log.WithFields(fields).Error(err)
 }
 
-func cacheHandler(router *router.Router) {
+func cacheHandler(router *router.Router, cacheRefresh int64, log *logrus.Logger) {
 	for {
 		time.Sleep(time.Duration(cacheRefresh) * time.Minute)
 
 		err := router.Cache.SetCache()
 		if err != nil {
-			logError("Cache refresh failed", err)
+			log.WithFields(logrus.Fields{"err": err.Error()}).Error(err)
 		}
 	}
 }
 
-func httpHandler(router *router.Router) {
+func httpHandler(router *router.Router, port string, log *logrus.Logger) {
 	http.Handle("/", router.Router)
 
 	log.Printf("Postgres API running in port: %s\n", port)
@@ -55,20 +58,26 @@ func httpHandler(router *router.Router) {
 }
 
 func main() {
+	log := logrus.New()
+	// log as JSON instead of the default ASCII formatter.
+	log.SetFormatter(&logrus.JSONFormatter{})
+
+	options := gatherOptions()
+
 	reportProblem := func(ev pq.ListenerEventType, err error) {
 		if err != nil {
 			fmt.Printf("Problem with listener, error: %s, event type: %d", err.Error(), ev)
 		}
 	}
 
-	listener := pq.NewListener(connectionString, 10*time.Second, time.Minute, reportProblem)
+	listener := pq.NewListener(options.connectionString, 10*time.Second, time.Minute, reportProblem)
 
-	driver, err := postgresdriver.NewPostgresDriverFromConnectionString(connectionString, listener)
+	driver, err := postgresdriver.NewPostgresDriverFromConnectionString(options.connectionString, listener)
 	if err != nil {
 		panic(err)
 	}
 
-	router, err := router.NewRouter(driver, driver, apiKeys, log)
+	router, err := router.NewRouter(driver, driver, options.apiKeys, log)
 	if err != nil {
 		panic(err)
 	}
@@ -77,8 +86,8 @@ func main() {
 
 	wg.Add(1)
 
-	go httpHandler(router)
-	go cacheHandler(router)
+	go httpHandler(router, options.port, log)
+	go cacheHandler(router, options.cacheRefresh, log)
 
 	wg.Wait()
 }


### PR DESCRIPTION
Simple PR to update `main.go` to use a `gatherOptions` func to collect env vars for configuration vs having them defined at the global scope.